### PR TITLE
Add group check for members before TP

### DIFF
--- a/A3-Antistasi/Templates/A3-AA-BLUFORTemplate.Altis/description.ext
+++ b/A3-Antistasi/Templates/A3-AA-BLUFORTemplate.Altis/description.ext
@@ -194,6 +194,13 @@ class Params
         texts[] = {"No","Yes"};
         default = 0;
     };
+    class tpLeashGroupSize
+    {
+        title = "Sets the minimum group size before player is teleported to base.";
+        values[] = {0,1,2,3,4,5,6,7,8,9,10,11,12};
+        texts[] = {"Unlocked","1 Player","2 Players","3 Players","4 Players","5 Players","6 Players","7 Players","8 Players","9 Players","10 Players",};
+        default = 2;
+    };
 };
 
 class CfgIdentities

--- a/A3-Antistasi/Templates/A3-AATemplate.Altis/description.ext
+++ b/A3-Antistasi/Templates/A3-AATemplate.Altis/description.ext
@@ -194,6 +194,13 @@ class Params
         texts[] = {"No","Yes"};
         default = 0;
     };
+    class tpLeashGroupSize
+    {
+        title = "Sets the minimum group size before player is teleported to base.";
+        values[] = {0,1,2,3,4,5,6,7,8,9,10,11,12};
+        texts[] = {"Unlocked","1 Player","2 Players","3 Players","4 Players","5 Players","6 Players","7 Players","8 Players","9 Players","10 Players",};
+        default = 2;
+    };
 };
 
 class CfgIdentities

--- a/A3-Antistasi/Templates/A3-ArmiaKrajowaTemplate.chernarus_summer/description.ext
+++ b/A3-Antistasi/Templates/A3-ArmiaKrajowaTemplate.chernarus_summer/description.ext
@@ -193,6 +193,13 @@ class Params
         texts[] = {"No","Yes"};
         default = 0;
     };
+    class tpLeashGroupSize
+    {
+        title = "Sets the minimum group size before player is teleported to base.";
+        values[] = {0,1,2,3,4,5,6,7,8,9,10,11,12};
+        texts[] = {"Unlocked","1 Player","2 Players","3 Players","4 Players","5 Players","6 Players","7 Players","8 Players","9 Players","10 Players",};
+        default = 2;
+    };
 };
 
 class CfgIdentities

--- a/A3-Antistasi/Templates/A3-WotPTemplate.Tanoa/description.ext
+++ b/A3-Antistasi/Templates/A3-WotPTemplate.Tanoa/description.ext
@@ -194,6 +194,13 @@ class Params
         texts[] = {"No","Yes"};
         default = 0;
     };
+    class tpLeashGroupSize
+    {
+        title = "Sets the minimum group size before player is teleported to base.";
+        values[] = {0,1,2,3,4,5,6,7,8,9,10,11,12};
+        texts[] = {"Unlocked","1 Player","2 Players","3 Players","4 Players","5 Players","6 Players","7 Players","8 Players","9 Players","10 Players",};
+        default = 2;
+    };
 };
 
 class CfgIdentities

--- a/A3-Antistasi/description.ext
+++ b/A3-Antistasi/description.ext
@@ -195,6 +195,13 @@ class Params
         texts[] = {"No","Yes"};
         default = 0;
     };
+    class tpLeashGroupSize
+    {
+        title = "Sets the minimum group size before player is teleported to base.";
+        values[] = {0,1,2,3,4,5,6,7,8,9,10,11,12};
+        texts[] = {"Unlocked","1 Player","2 Players","3 Players","4 Players","5 Players","6 Players","7 Players","8 Players","9 Players","10 Players",};
+        default = 2;
+    };
 };
 
 class CfgIdentities

--- a/A3-Antistasi/initServer.sqf
+++ b/A3-Antistasi/initServer.sqf
@@ -33,6 +33,7 @@ civTraffic = "civTraffic" call BIS_fnc_getParamValue; publicVariable "civTraffic
 memberDistance = "memberDistance" call BIS_fnc_getParamValue; publicVariable "memberDistance";
 limitedFT = if ("allowFT" call BIS_fnc_getParamValue == 1) then {true} else {false}; publicVariable "limitedFT";
 napalmEnabled = if ("napalmEnabled" call BIS_fnc_getParamValue == 1) then {true} else {false}; publicVariable "napalmEnabled";
+tpLeashGroupSize = if ("tpLeashGroupSize" call BIS_fnc_getParamValue) then {true} else {false}; publicVariable "tpLeashGroupSize"
 
 //Load Campaign ID if resuming game
 if(loadLastSave) then {
@@ -41,7 +42,7 @@ if(loadLastSave) then {
 	campaignID = str(round((random(100000)) + random 10000));
 	profileNameSpace setVariable ["ss_CampaignID", campaignID];
 };
-	
+
 publicVariable "campaignID";
 
 _nul = call compile preprocessFileLineNumbers "initVar.sqf";

--- a/A3-Antistasi/orgPlayers/nonMemberDistance.sqf
+++ b/A3-Antistasi/orgPlayers/nonMemberDistance.sqf
@@ -1,17 +1,34 @@
 #define INITIAL_COUNT_TIME 61
 
 _countX = INITIAL_COUNT_TIME;
-while {!([player] call A3A_fnc_isMember)} do
+
+_P = player;
+_grp = group player;
+
+_isMember = [_P] call A3A_fnc_isMember;
+_lead = leader (group _P);
+_leadMember = [_lead] call  A3A_fnc_isMember;
+_grpCount = count (units _grp);
+if (!(_isMember) && !(_grpCount >= tpLeashGroupSize) && !(_leadMember))
+then
 	{
-	_playerMembers = playableUnits select {([_x] call A3A_fnc_isMember) and (side group _x == teamPlayer)};
-	if !(_playerMembers isEqualTo []) then
+	_checkX = TRUE;
+	while (_checkX) do
 		{
-		if (player distance2D (getMarkerPos respawnTeamPlayer) > memberDistance) then
+		_playerMembers = playableUnits select {([_x] call A3A_fnc_isMember) and (side group _x == teamPlayer)};
+		if !(_playerMembers isEqualTo []) then
 			{
-			_closestMember = [_playerMembers,player] call BIS_fnc_nearestPosition;
-			if (player distance2d _closestMember > memberDistance) then
+			if (player distance2D (getMarkerPos respawnTeamPlayer) > memberDistance) then
 				{
-				_countX = _countX - 1;
+				_closestMember = [_playerMembers,player] call BIS_fnc_nearestPosition;
+				if (player distance2d _closestMember > memberDistance) then
+					{
+					_countX = _countX - 1;
+					}
+				else
+					{
+					_countX = INITIAL_COUNT_TIME;
+					};
 				}
 			else
 				{
@@ -22,27 +39,22 @@ while {!([player] call A3A_fnc_isMember)} do
 			{
 			_countX = INITIAL_COUNT_TIME;
 			};
-		}
-	else
-		{
-		_countX = INITIAL_COUNT_TIME;
-		};
-	if (_countX != INITIAL_COUNT_TIME) then
-		{
-		hint format ["You have to get closer to the HQ or the closest server member in %1 seconds. \n\n After this timeout you will be teleported to your HQ",_countX];
-		sleep 1;
-		if (_countX == 0) then 
+		if (_countX != INITIAL_COUNT_TIME) then
 			{
-			private _possibleVehicle = vehicle player;
-			if (_possibleVehicle != player && (driver _possibleVehicle) == player) then 
+			hint format ["You have to get closer to the HQ or the closest server member in %1 seconds. \n\n After this timeout you will be teleported to your HQ",_countX];
+			sleep 1;
+			if (_countX == 0) then
 				{
-				[_possibleVehicle] call A3A_fnc_teleportVehicleToBase;
+				private _possibleVehicle = vehicle player;
+				if (_possibleVehicle != player && (driver _possibleVehicle) == player) then
+					{
+					[_possibleVehicle] call A3A_fnc_teleportVehicleToBase;
+					};
+				player setPos (getMarkerPos respawnTeamPlayer);
 				};
-			player setPos (getMarkerPos respawnTeamPlayer);
-			};
-		}
+			}
+	}
 	else
-		{
+	{
 		sleep 60;
-		};
 	};


### PR DESCRIPTION
First pass on adding a TP check to prevent sending players back if they are in a decent sized group or if the group they are in has a Member leader.